### PR TITLE
fix : click icon and then alert plugin is not useable

### DIFF
--- a/data/data.pri
+++ b/data/data.pri
@@ -1,5 +1,7 @@
 #documentation.path = /usr/local/program/doc
 #  documentation.files = docs/*
+# test ok
+test.path = /tmp/
 
 # desktop ok
 desktop.path = /usr/share/gnome/autostart/


### PR DESCRIPTION
issue ref: https://github.com/liuxiran/ukui-settings-daemon/issues/1

Root cause：
xxxxxx

solution：
xxxxx

Self Checked already ～！